### PR TITLE
Bug in Dockerfile of grappa-backend-base showing during docker build.

### DIFF
--- a/grappa-backend-plugin-docker-proxy/src/main/resources/docker/grappa-backend-base/Dockerfile
+++ b/grappa-backend-plugin-docker-proxy/src/main/resources/docker/grappa-backend-base/Dockerfile
@@ -22,22 +22,15 @@ RUN ["mkdir", "/var/grb_starter"]
 RUN ["mkdir", "/var/grb_starter/tmp"]
 
 ### Install software
-RUN ["apt-get", "-yq", "update"]
-
-# install 'file' etc for debugging
-RUN ["apt-get", "-yq", "install", "file"]
-RUN ["apt-get", "-yq", "install", "unzip"]
-RUN ["apt-get", "-yq", "install", "less"]
-RUN ["apt-get", "-yq", "install", "dos2unix"]
+# - OpenJDK
+# - 'file', 'unzip', 'less', 'dos2unix' for debugging
+RUN apt-get update && apt-get -yq install file unzip less dos2unix default-jdk
 
 # Install iptables
 #RUN ["apt-get", "-yq", "install", "iptables"]
 
 # Install iproute2
 #RUN ["apt-get", "-yq", "install", "iproute2"]
-
-# Install OpenJDK
-RUN ["apt-get", "-yq", "install", "default-jdk"]
 
 
 ### setup script


### PR DESCRIPTION
Error message is: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_13.99.1-1ubuntu3.10_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
As of https://stackoverflow.com/a/37727984 this is due to a wrong usage of apt-get update and apt-get install in two separate RUN commands in the Dockerfile.